### PR TITLE
feat(enacsoft): add enacsoft.epfl.ch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,19 @@ UID := $(shell id -u)
 GID := $(shell id -g)
 
 run:
-	docker-compose \
+	docker compose \
 		-f docker-compose.yml \
 		-f docker-compose-enacrepo.yml \
 		-f docker-compose-enacitarchives.yml \
+		-f docker-compose-enacsoft.yml \
 		up --build -d
 
 down:
-	docker-compose \
+	docker compose \
 		-f docker-compose.yml \
 		-f docker-compose-enacrepo.yml \
 		-f docker-compose-enacitarchives.yml \
+		-f docker-compose-enacsoft.yml \
 	  down
 
 generate-selfsigned-cert:

--- a/docker-compose-enacitarchives.yml
+++ b/docker-compose-enacitarchives.yml
@@ -2,7 +2,6 @@ version: "3.8"
 services:
 
   enacitarchives:
-    # image: php:8.2-apache
     build:
       context: hosts/enacitarchives.epfl.ch
     user: "www-data:www-data"

--- a/docker-compose-enacsoft.yml
+++ b/docker-compose-enacsoft.yml
@@ -1,0 +1,25 @@
+version: "3.8"
+services:
+
+  enacsoft:
+    build:
+      context: hosts/enacsoft.epfl.ch
+    user: "www-data:www-data"
+    volumes:
+      - enacsoft-webshare:/var/www/html:ro
+      - ./hosts/enacsoft.epfl.ch/enacsoft.conf:/etc/apache2/sites-enabled/enacsoft.conf:ro
+      - ./hosts/enacsoft.epfl.ch/tequila.conf:/etc/apache2/sites-enabled/tequila.conf:ro
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.enacsoft.tls=true"
+      - "traefik.http.routers.enacsoft.rule=PathPrefix(`/`)"
+      - "traefik.http.routers.enacsoft.rule=Host(`enacsoft.epfl.ch`)"
+
+volumes:
+  enacsoft-webshare:
+    driver: local
+    driver_opts:
+      type: cifs
+      o: addr=enac1arch.epfl.ch,username=${USER_ENACIT_WEBHOSTING_USERNAME},domain=${USER_ENACIT_WEBHOSTING_DOMAIN},password=${USER_ENACIT_WEBHOSTING_PASSWORD},ro
+      device: "//enac1arch.epfl.ch/ENAC-IT/webhosting/enacsoft/"

--- a/hosts/enacsoft.epfl.ch/Dockerfile
+++ b/hosts/enacsoft.epfl.ch/Dockerfile
@@ -1,0 +1,22 @@
+FROM php:8.2-apache
+
+RUN rm /etc/apache2/sites-enabled/000-default.conf
+RUN a2enmod include cgi info rewrite
+
+RUN apt -qy update \
+    && apt -qy install sed wget build-essential ca-certificates \
+    apache2-dev libssl-dev libc-client-dev libkrb5-dev libpq-dev
+
+# Install Tequila
+RUN cd / \
+    && wget https://tequila.epfl.ch/download/2.0/tequila-apache-C-2.0.17.tgz \
+    && tar zxvf tequila-apache-C-2.0.17.tgz
+RUN cd /tequila-2.0.17/Apache/C/ \
+    && sed -i 's/ && service httpd restart//g' Makefile
+RUN cd /tequila-2.0.17/Apache/C/ \
+    && make && make install
+
+RUN mkdir /var/tequila \
+    && chown www-data: /var/tequila
+# RUN mkdir /var/log/apache2/ \
+#     && chown www-data: /var/log/apache2/

--- a/hosts/enacsoft.epfl.ch/enacsoft.conf
+++ b/hosts/enacsoft.epfl.ch/enacsoft.conf
@@ -1,0 +1,61 @@
+Alias /robots.txt   /var/www/html/main/robots.txt
+Alias /favicon.ico  /var/www/html/main/favicon.ico
+Alias /charte2010   /var/www/html/enacit-webres/charte2010
+Alias /charte-rsc   /var/www/html/enacit-webres/charte-rsc
+Alias /img          /var/www/html/enacit-webres/img
+Alias /js           /var/www/html/enacit-webres/js
+Alias /php_apps/    /var/www/html/enacit-webres/php_apps/
+Alias /icon_gif     /var/www/html/enacit-webres/oldimages/icon_gif
+Alias /icon_xbm     /var/www/html/enacit-webres/oldimages/icon_xbm
+Alias /anim_gif     /var/www/html/enacit-webres/oldimages/anim_gif
+Alias /logos        /var/www/html/enacit-webres/oldimages/logos
+Alias /backgrounds  /var/www/html/enacit-webres/oldimages/backgrounds
+
+<VirtualHost *:80>
+    # Sur port 80, site de redirection uniquement vers le site 443 ci-dessous !
+    ServerName   enacsoft.epfl.ch
+
+    ServerAdmin enacit@epfl.ch
+    DocumentRoot /var/www/html/enacsoft
+
+
+    # Pour ce site, je fais passer les *.shtml avant les *.php dès juillet 2014
+    DirectoryIndex index.shtml index.html index.htm index.php index.en.php default.php default.html default.htm /cgi-bin/error.pl/noindex
+
+    # Manip. de fichiers par PHP autorisée seulement dans arborescence courante
+    php_admin_value open_basedir "/var/www/html:/var/www/html/enacit-webres/php_apps"
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+    <Directory "/var/www/html/enacsoft">
+        # J'ajoute FileInfo pour pouvoir utiliser, dans cette arborescence, des .htaccess
+        # désactivant le AddDefaultCharset afin que les fichiers UTF-8 ayant la directive
+        # <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />  fonctionnent
+        # (nécessaire p.ex. pour markdown-pandoc et reserv-vehicules...)
+        AllowOverride Limit AuthConfig Indexes FileInfo Options
+    </Directory>
+
+
+    # Fichiers spécifiquement en UTF-8
+    <FilesMatch "resp_unites.shtml">
+           AddDefaultCharset UTF-8
+    </FilesMatch>
+    <FilesMatch "resp_unites-old-v1.1.shtml">
+           AddDefaultCharset UTF-8
+    </FilesMatch>
+
+    # Arborescences en UTF-8
+    <Location /intranet>
+           AddDefaultCharset UTF-8
+    </Location>
+
+    <Location /monitoring>
+            AddDefaultCharset UTF-8
+    </Location>
+
+    <Location /roles-it>
+           AddDefaultCharset UTF-8
+    </Location>
+
+</VirtualHost>

--- a/hosts/enacsoft.epfl.ch/tequila.conf
+++ b/hosts/enacsoft.epfl.ch/tequila.conf
@@ -1,0 +1,10 @@
+LoadModule tequila_module /usr/lib/apache2/modules/mod_tequila.so
+
+<IfModule mod_tequila.c>
+  TequilaLogLevel        2
+  TequilaLog             /var/log/apache2/tequila.log
+  TequilaServer          tequila.epfl.ch
+  # TequilaSessionDir      /var/www/Tequila/Sessions
+  TequilaSessionDir      /var/tequila
+  TequilaSessionMax      3600
+</IfModule>


### PR DESCRIPTION
Add enacoft.epfl.ch to A10 (load balancer) hosting.
Sill used by enacdrives clients for client updating process, tested successfully locally.